### PR TITLE
Wire up boost status text

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,9 @@ module.exports = {
     'plugin:vue/essential',
     'eslint:recommended'
   ],
+  globals: {
+    MQTT_SERVER: 'readonly'
+  },
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ yarn install
 ### Generate a distributable web app folder
 
 This creates a minified copy of the code in the `/dist/` directory.
+The environment variable `MQTT_SERVER` specifies the ip address of the server where openHAB is running.
+Omit this environment variable to default to localhost.
 
 ```sh
-yarn build
+MQTT_SERVER=192.168.1.23 yarn build
 ```
 
 In this folder will be an index.html you can open locally or on the Pi's browser.
@@ -32,10 +34,12 @@ This will compile and hot-reload code in realtime.
 It also has the benefit of checking your code and reporting errors when they happen.
 
 ```sh
-yarn run serve
+MQTT_SERVER=192.168.1.23 yarn run serve
 ```
 
-### Lints and fixes files
+As with the build command, the `MQTT_SERVER` environment variable is optional and will default to localhost if omitted, but likely you want to develop from another machine and connect remotely to the openHAB server.
+
+### Lint and fix files
 
 If you need to check for errors without starting the local webserver, you can use the following command.
 
@@ -43,7 +47,7 @@ If you need to check for errors without starting the local webserver, you can us
 yarn run lint
 ```
 
-### Customize configuration
+### Extended features
 
 This app was built using [Vue.js](https://vuejs.org/) and [Vue CLI](https://cli.vuejs.org/).
 For extending the configuration, see [Configuration Reference](https://cli.vuejs.org/config/).

--- a/src/components/home-screen.vue
+++ b/src/components/home-screen.vue
@@ -84,11 +84,9 @@
         {{ currentHumidity }}<span class="symbol">%</span>
       </div>
     </div>
-    <div class="bottom-container">
-      <!-- Show this when boost mode is on temporarily with a set timer -->
-      <span v-show="boostEnabled && boostTimeRemaining">Boost mode: {{ boostTimeRemaining }} remaining</span>
-      <!-- Show this when boost mode is ON without a timer -->
-      <span v-show="boostEnabled && !boostTimeRemaining">Boost mode ON</span>
+    <div class="bottom-container" v-show="boostEnabled">
+      Boost mode enabled.
+      <span v-show="boostTimeRemaining">{{ boostTimeRemaining }} minute(s) remaining.</span>
     </div>
   </div>
 </template>
@@ -130,8 +128,6 @@ export default {
     // Some variables in $store.state we want to read
     // https://vuex.vuejs.org/guide/state.html#the-mapstate-helper
     ...mapState([
-      'boostEnabled',
-      'boostTimeRemaining',
       'currentTemperature',
       'currentHumidity',
       'icons',
@@ -144,6 +140,18 @@ export default {
       'showHotWater',
       'showHumidity'
     ]),
+    boostEnabled() {
+      const modeState = this.$store.state.modes[this.selectedMode]
+      console.log(modeState)
+      return modeState && modeState.boostEnabled
+    },
+    boostTimeRemaining() {
+      const modeState = this.$store.state.modes[this.selectedMode]
+      if (modeState) {
+        return modeState.boostTimeRemaining
+      }
+      return null
+    },
     targetTemperature() {
       return this.$store.getters.targetTemperature
     }
@@ -201,13 +209,22 @@ export default {
 .active-temp {
   font-size: 30vh;
   left: 3%;
-  top: 25%;
+  line-height: 100%;
+  top: 29%;
   width: 50vw;
 }
 
 .active-temp > .symbol {
   font-size: 18vh;
   vertical-align: text-top;
+}
+
+.bottom-container {
+  bottom: 0;
+  height: 8vh;
+  left: 4%;
+  position: absolute;
+  width: 100%;
 }
 
 .current-temp {
@@ -233,12 +250,6 @@ export default {
 
 .current-humidity > .symbol {
   font-size: 10vh;
-}
-
-.bottom-container {
-  bottom: 0;
-  left: 4%;
-  position: absolute;
 }
 
 .grid {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,13 @@
+const webpack = require('webpack')
+
 module.exports = {
+  configureWebpack: {
+    plugins: [
+      new webpack.DefinePlugin({
+        MQTT_SERVER: JSON.stringify(process.env.MQTT_SERVER || 'localhost')
+      })
+    ]
+  },
   css: {
     sourceMap: true
   },


### PR DESCRIPTION
Resolves #1
Resolves #2

**What to test:**

Start the server using the environment `MQTT_SERVER` environment variable to specify your server, eg.: `MQTT_SERVER=10.10.10.51 yarn serve`. You should now be able to toggle boost mode for any of the given modes and see if they are working as expected.