### PR TITLE
Reduced memory and CPU usage by removing animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "deploy": "ssh pi@$HESTIA 'rm -r scripts/oneui/*' && scp -r dist/* pi@$HESTIA:scripts/oneui && ssh pi@$HESTIA 'sudo killall -TERM kweb'"
+    "deploy": "ssh pi@$HESTIA 'rm -r scripts/oneui/*' && scp -r dist/* pi@$HESTIA:scripts/oneui && ssh pi@$HESTIA 'which kweb && sudo killall -TERM kweb || which midori && sudo killall -TERM midori'"
   },
   "engines": {
     "node": ">=10.1",

--- a/src/components/home-screen.vue
+++ b/src/components/home-screen.vue
@@ -219,7 +219,8 @@ export default {
 
 /* Apply to any mode that is running to give it a glowing effect */
 .animated {
-  animation: changecolor 2s steps(8) infinite alternate;
+  border-top: 5px white solid;
+  margin-top: 15px !important;
 }
 
 .active-temp {
@@ -309,24 +310,24 @@ export default {
   display: inline-block;
   float: left;
   height: 100%;
-  margin-top: 4vh;
+  margin-top: 20px;
   width: 26vh;
 }
 
 .mode-btn.cool {
-  margin-top: 3vh;
+  margin-top: 20px;
 }
 
 .mode-btn.heat {
-  margin-top: 4.4vh;
+  margin-top: 20px;
 }
 
 .mode-btn.humidity {
-  margin-top: 2.8vh;
+  margin-top: 20px;
 }
 
 .mode-btn.hotwater {
-  margin-top: 4.4vh;
+  margin-top: 20px;
 }
 
 .mode-btn.info {

--- a/src/components/icon-fan.vue
+++ b/src/components/icon-fan.vue
@@ -2,7 +2,7 @@
   <svg
     :width="size"
     :height="size"
-    viewBox="0 0 46 46"
+    viewBox="0 0 40 46"
     class="icon"
     fill="none"
     stroke="currentColor"


### PR DESCRIPTION
This makes the LCD touchscreen noticeable more responsive at the expense of not having the icon fade in and out.  Instead of using a fade to indicate the functionality is on, there's a bar above the icons which are currently running.

There's also a small change to the deploy target to make it compatible with systems running either kweb or midori.

This change is a performance improvement no matter what version of Debian or which browser is in use, but it's most important for Debian 11 (bullseye) and Midori (as kweb is no longer maintained and the libraries it needs were dropped in Debian 11).